### PR TITLE
Added math.h to avoid compiler warnings

### DIFF
--- a/src/lcec_deasda.c
+++ b/src/lcec_deasda.c
@@ -18,6 +18,7 @@
 
 #include "lcec.h"
 #include "lcec_deasda.h"
+#include "math.h"
 
 #define DEASDA_PULSES_PER_REV_DEFLT (1280000)
 #define DEASDA_RPM_FACTOR           (0.1)

--- a/src/lcec_stmds5k.c
+++ b/src/lcec_stmds5k.c
@@ -18,6 +18,7 @@
 
 #include "lcec.h"
 #include "lcec_stmds5k.h"
+#include "math.h"
 
 #define STMDS5K_PCT_REG_FACTOR (0.5 * (double)0x7fff)
 #define STMDS5K_PCT_REG_DIV    (2.0 / (double)0x7fff)


### PR DESCRIPTION
Just to get rid of

```
lcec_stmds5k.c: In function ‘lcec_stmds5k_read’:
lcec_stmds5k.c:404:33: warning: incompatible implicit declaration of built-in function ‘fabs’
   *(hal_data->vel_fb_rpm_abs) = fabs(rpm);
                                 ^
gcc -o lcec_deasda.o -I. -I/usr/include/xenomai -D_GNU_SOURCE -D_REENTRANT -D__XENO__ -DTHREAD_FLAVOR_ID=2 -DRTAPI -D_GNU_SOURCE -D_FORTIFY_SOURCE=0 -D__MODULE__ -mieee-fp -I/home/master/machinekit/include -fPIC -g -funwind-tables -Os -c lcec_deasda.c
lcec_deasda.c: In function ‘lcec_deasda_read’:
lcec_deasda.c:488:33: warning: incompatible implicit declaration of built-in function ‘fabs’
   *(hal_data->vel_fb_rpm_abs) = fabs(rpm);
```
