### PR TITLE
Revert "Added math.h to avoid compiler warnings"

### DIFF
--- a/src/lcec_deasda.c
+++ b/src/lcec_deasda.c
@@ -18,7 +18,6 @@
 
 #include "lcec.h"
 #include "lcec_deasda.h"
-#include "math.h"
 
 #define DEASDA_PULSES_PER_REV_DEFLT (1280000)
 #define DEASDA_RPM_FACTOR           (0.1)

--- a/src/lcec_stmds5k.c
+++ b/src/lcec_stmds5k.c
@@ -18,7 +18,6 @@
 
 #include "lcec.h"
 #include "lcec_stmds5k.h"
-#include "math.h"
 
 #define STMDS5K_PCT_REG_FACTOR (0.5 * (double)0x7fff)
 #define STMDS5K_PCT_REG_DIV    (2.0 / (double)0x7fff)


### PR DESCRIPTION
Reverts sittner/linuxcnc-ethercat#34
Does not work for kernel space and is already handled by rtapi_math.h