### PR TITLE
Fix segfault during `lcec_update_slave_state_hal()` on Machinekit HAL

### DIFF
--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -1106,7 +1106,7 @@ lcec_slave_state_t *lcec_init_slave_state_hal(char *master_name, char *slave_nam
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for %s.%s.%s failed\n", LCEC_MODULE_NAME, master_name, slave_name);
     return NULL;
   }
-  memset(hal_data, 0, sizeof(lcec_master_data_t));
+  memset(hal_data, 0, sizeof(lcec_slave_state_t));
 
   // export pins
   if (lcec_pin_newf_list(hal_data, slave_pins, LCEC_MODULE_NAME, master_name, slave_name) != 0) {


### PR DESCRIPTION
The `lcec_init_slave_state_hal()` function does a `memset()` to clear
the bit of shm where the slave state struct is stored.  However, it
overran that space and cleared part of the previous slave state struct
where dummy signal pointers were stored.  If the update function is
added to a thread and started, and no other signal has been netted to
the pins, the `lcec_update_slave_state_hal()` attempts to update the
pins with zeroed dummy signal pointers, and causes `rtapi_app` to
crash with a segmentation faults.

I suspect that the `memset()` is unnecessary, since POSIX shm segments
are initialized to 0, according to shm_open(3), and `hal_malloc()` shm
segments are never freed and thus never reused, according to
hall_malloc(3).  This may not be true for RTAI threads, however, so
being conservative, I leave the `memset()` call in place.