### PR TITLE
Sync unit implementaion

### DIFF
--- a/DC-SYNC.md
+++ b/DC-SYNC.md
@@ -260,7 +260,65 @@ Each slave that supports Distributed Clocks can have a `<dcConf>` child element:
 | `sync1Cycle` | integer (ns) or `*N` | SYNC1 period (same integer-only `*N` syntax supported). |
 | `sync1Shift` | integer (ns) | SYNC1 phase shift relative to SYNC0. |
 
-### 6.3 Example Configuration
+### 6.3 Slave-Level Sync Unit Attributes
+
+Each `<slave>` can be assigned to a process-data Sync Unit. A Sync Unit owns a separate EtherCAT domain and can be exchanged at a slower integer multiple of the master's `appTimePeriod`.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `syncUnit` | string | Name of the Sync Unit/domain. Slaves with the same name share the same process-data domain. Default: `default`. |
+| `syncUnitCycle` | integer (ns) or `*N` | Process-data exchange period for the Sync Unit. Must be a positive multiple of `appTimePeriod`. Default: `*1`. |
+
+All slaves with the same `syncUnit` name must use the same `syncUnitCycle`. If these attributes are omitted, the slave behaves as before: it is placed in the `default` Sync Unit and exchanged every master cycle.
+
+`syncUnitCycle` controls when PDO data is queued, received, and when the slave's HAL read/write callbacks run. It does not replace Distributed Clock settings. For DC-capable slaves, keep `<dcConf>` aligned with the intended hardware sampling/update period.
+
+### 6.4 Sync Unit Example
+
+```xml
+<masters>
+  <master idx="0"
+          appTimePeriod="1000000"
+          refClockSyncCycles="1">
+
+    <!-- Fast Sync Unit: exchanged every servo cycle, 1 ms -->
+    <slave idx="0" type="EK1100"
+           syncUnit="fast"
+           syncUnitCycle="*1"/>
+
+    <slave idx="1" type="EL7211"
+           name="x-drive"
+           syncUnit="fast"
+           syncUnitCycle="*1">
+      <dcConf assignActivate="0x0300"
+              sync0Cycle="*1"
+              sync0Shift="0"/>
+    </slave>
+
+    <slave idx="2" type="EL7211"
+           name="y-drive"
+           syncUnit="fast"
+           syncUnitCycle="*1">
+      <dcConf assignActivate="0x0300"
+              sync0Cycle="*1"
+              sync0Shift="0"/>
+    </slave>
+
+    <!-- Slow Sync Unit: exchanged every four servo cycles, 4 ms -->
+    <slave idx="3" type="EL1809"
+           name="inputs"
+           syncUnit="slow-io"
+           syncUnitCycle="*4"/>
+
+    <slave idx="4" type="EL2809"
+           name="outputs"
+           syncUnit="slow-io"
+           syncUnitCycle="*4"/>
+  </master>
+</masters>
+```
+
+### 6.5 DC Example Configuration
 
 ```xml
 <masters>

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ EtherCAT bus configuration is done via XML files that are processed by `lcec_con
 - Slave devices and their vendor/product IDs
 - PDO mappings (process data object assignments)
 - DC sync settings (distributed clocks)
+- Sync Units for grouping slaves into separate process-data domains with different integer-multiple update rates
 - Init commands (CoE SDO / SoE IDN writes executed at startup)
 
 See the [`examples/`](examples/) directory for sample configurations.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 include ../config.mk
 
-SUBDIRS = generic-complex swm-fm45a
+SUBDIRS = generic-complex swm-fm45a sync-units
 
 install-examples:
 	mkdir -p $(DESTDIR)$(EMC2_HOME)/share/linuxcnc-ethercat/examples

--- a/examples/sync-units/README
+++ b/examples/sync-units/README
@@ -1,0 +1,15 @@
+Sync Unit example
+=================
+
+This example shows how to split one EtherCAT master into two process-data Sync
+Units:
+
+- "fast" is exchanged every master cycle.
+- "slow-io" is exchanged every four master cycles.
+
+The master appTimePeriod is 1 ms, so syncUnitCycle="*4" means a 4 ms PDO
+exchange period for the slow I/O group.
+
+All slaves in the same syncUnit must use the same syncUnitCycle. If syncUnit and
+syncUnitCycle are omitted, a slave is assigned to the default Sync Unit and is
+exchanged every master cycle, matching the old behavior.

--- a/examples/sync-units/ethercat-conf.xml
+++ b/examples/sync-units/ethercat-conf.xml
@@ -1,0 +1,39 @@
+<masters>
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1">
+
+    <!-- Fast Sync Unit: exchanged every servo cycle, 1 ms. -->
+    <slave idx="0" type="EK1100"
+           syncUnit="fast"
+           syncUnitCycle="*1"/>
+
+    <slave idx="1" type="EL7211"
+           name="x-drive"
+           syncUnit="fast"
+           syncUnitCycle="*1">
+      <dcConf assignActivate="0x0300"
+              sync0Cycle="*1"
+              sync0Shift="0"/>
+    </slave>
+
+    <slave idx="2" type="EL7211"
+           name="y-drive"
+           syncUnit="fast"
+           syncUnitCycle="*1">
+      <dcConf assignActivate="0x0300"
+              sync0Cycle="*1"
+              sync0Shift="0"/>
+    </slave>
+
+    <!-- Slow Sync Unit: exchanged every four servo cycles, 4 ms. -->
+    <slave idx="3" type="EL1809"
+           name="inputs"
+           syncUnit="slow-io"
+           syncUnitCycle="*4"/>
+
+    <slave idx="4" type="EL2809"
+           name="outputs"
+           syncUnit="slow-io"
+           syncUnitCycle="*4"/>
+
+  </master>
+</masters>

--- a/src/conf.c
+++ b/src/conf.c
@@ -842,8 +842,11 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
   }
 
   const LCEC_CONF_TYPELIST_T *slaveType = NULL;
+  int syncUnitCycle;
   p->confType = lcecConfTypeSlave;
   p->type = lcecSlaveTypeInvalid;
+  strncpy(p->syncUnit, "default", LCEC_CONF_STR_MAXLEN);
+  p->syncUnitCycle = state->currMaster->appTimePeriod;
 
   // pre parse slave type to avoid attribute ordering problems
   const char **iter = attr;
@@ -890,6 +893,23 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
       continue;
     }
 
+    if (strcmp(name, "syncUnit") == 0) {
+      strncpy(p->syncUnit, val, LCEC_CONF_STR_MAXLEN);
+      p->syncUnit[LCEC_CONF_STR_MAXLEN - 1] = 0;
+      continue;
+    }
+
+    if (strcmp(name, "syncUnitCycle") == 0) {
+      syncUnitCycle = parseSyncCycle(state, val);
+      if (syncUnitCycle <= 0) {
+        fprintf(stderr, "%s: ERROR: Invalid syncUnitCycle %s\n", modname, val);
+        XML_StopParser(inst->parser, 0);
+        return;
+      }
+      p->syncUnitCycle = syncUnitCycle;
+      continue;
+    }
+
     // generic only attributes
     if (p->type == lcecSlaveTypeGeneric) {
       // parse vid (hex value)
@@ -920,6 +940,20 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
   // set default name
   if (p->name[0] == 0) {
     snprintf(p->name, LCEC_CONF_STR_MAXLEN, "%d", p->index);
+  }
+
+  if (p->syncUnit[0] == 0) {
+    fprintf(stderr, "%s: ERROR: Slave %s has empty syncUnit attribute\n", modname, p->name);
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  if (p->syncUnitCycle == 0 || state->currMaster->appTimePeriod == 0 ||
+      (p->syncUnitCycle % state->currMaster->appTimePeriod) != 0) {
+    fprintf(stderr, "%s: ERROR: Slave %s syncUnitCycle %u is not a positive multiple of appTimePeriod %u\n",
+      modname, p->name, p->syncUnitCycle, state->currMaster->appTimePeriod);
+    XML_StopParser(inst->parser, 0);
+    return;
   }
 
   // type is required

--- a/src/conf.h
+++ b/src/conf.h
@@ -318,6 +318,8 @@ typedef struct {
   size_t idnConfigLength;          /**< Cumulative byte size of all SoE IDN config data
                                     *   (including all @ref LCEC_CONF_IDNCONF_T headers). */
   unsigned int modParamCount;      /**< Number of @ref LCEC_CONF_MODPARAM_T records that follow. */
+  uint32_t syncUnitCycle;          /**< Process-data cycle time for this slave's Sync Unit (ns). */
+  char syncUnit[LCEC_CONF_STR_MAXLEN]; /**< Sync Unit name. Slaves with the same name share a domain. */
   char name[LCEC_CONF_STR_MAXLEN]; /**< Human-readable slave name used as the HAL pin prefix.
                                     *   Defaults to the decimal string of @c index. */
 } LCEC_CONF_SLAVE_T;

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -195,6 +195,7 @@ do {                        \
 
 struct lcec_master;
 struct lcec_slave;
+struct lcec_sync_unit;
 
 /**
  * @brief Callback invoked before slave initialisation to query PDO entry counts.
@@ -300,6 +301,23 @@ typedef struct lcec_master_data {
 #endif
 } lcec_master_data_t;
 
+typedef struct lcec_sync_unit {
+  struct lcec_sync_unit *prev;
+  struct lcec_sync_unit *next;
+  char name[LCEC_CONF_STR_MAXLEN];
+  uint32_t cycle_time;
+  unsigned int cycle_divider;
+  unsigned int cycle_counter;
+  int pdo_entry_count;
+  ec_pdo_entry_reg_t *pdo_entry_regs;
+  ec_domain_t *domain;
+  uint8_t *process_data;
+  int process_data_len;
+  int queued;
+  int process;
+  int write;
+} lcec_sync_unit_t;
+
 /**
  * @brief HAL pins exposing a single slave's EtherCAT application-layer (AL) state.
  *
@@ -348,6 +366,8 @@ typedef struct lcec_master {
   ec_domain_t *domain;             /**< EtherCAT process-data domain handle. */
   uint8_t *process_data;           /**< Pointer to the mapped process-data image for the domain. */
   int process_data_len;            /**< Size of the process-data image in bytes. */
+  lcec_sync_unit_t *first_sync_unit;
+  lcec_sync_unit_t *last_sync_unit;
   struct lcec_slave *first_slave;  /**< Head of the slave linked list for this master. */
   struct lcec_slave *last_slave;   /**< Tail of the slave linked list for this master. */
   lcec_master_data_t *hal_data;    /**< Per-master HAL state pins. */
@@ -472,9 +492,12 @@ typedef struct lcec_slave {
   struct lcec_slave  *prev;            /**< Previous slave in the master's list, or NULL if head. */
   struct lcec_slave  *next;            /**< Next slave in the master's list, or NULL if tail. */
   struct lcec_master *master;          /**< Back-pointer to the owning master. */
+  lcec_sync_unit_t   *sync_unit;
   int                 index;           /**< EtherCAT bus position of this slave (ring position). */
   LCEC_SLAVE_TYPE_T   type;            /**< Driver type identifier used to select the device driver. */
   char                name[LCEC_CONF_STR_MAXLEN]; /**< Human-readable slave name from the XML configuration. */
+  char                sync_unit_name[LCEC_CONF_STR_MAXLEN];
+  uint32_t            sync_unit_cycle;
   uint32_t            vid;             /**< EtherCAT vendor ID (must match the physical device). */
   uint32_t            pid;             /**< EtherCAT product code (must match the physical device). */
   int                 pdo_entry_count; /**< Number of PDO entries this slave requires in the domain. */

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -368,6 +368,7 @@ typedef struct lcec_master {
   int process_data_len;            /**< Size of the process-data image in bytes. */
   lcec_sync_unit_t *first_sync_unit;
   lcec_sync_unit_t *last_sync_unit;
+  int sync_units_started;           /**< Non-zero after OP was reached once and Sync Unit dividers may run. */
   struct lcec_slave *first_slave;  /**< Head of the slave linked list for this master. */
   struct lcec_slave *last_slave;   /**< Tail of the slave linked list for this master. */
   lcec_master_data_t *hal_data;    /**< Per-master HAL state pins. */

--- a/src/main.c
+++ b/src/main.c
@@ -107,6 +107,7 @@ int rtapi_app_main(void) {
   int slave_count;
   lcec_master_t *master;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
   char name[HAL_NAME_LEN + 1];
   ec_pdo_entry_reg_t *pdo_entry_regs;
   lcec_slave_sdoconf_t *sdo_config;
@@ -151,14 +152,19 @@ int rtapi_app_main(void) {
       goto fail2;
     }
 
-    // create domain
-    if (!(master->domain = ecrt_master_create_domain(master->master))) {
-      rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s domain creation failed\n", master->name);
-      goto fail2;
+    // create one process-data domain per Sync Unit
+    for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+      if (!(sync_unit->domain = ecrt_master_create_domain(master->master))) {
+        rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s domain creation failed\n",
+          master->name, sync_unit->name);
+        goto fail2;
+      }
+      if (master->domain == NULL) {
+        master->domain = sync_unit->domain;
+      }
     }
 
     // initialize slaves
-    pdo_entry_regs = master->pdo_entry_regs;
     for (slave = master->first_slave; slave != NULL; slave = slave->next) {
       // read slave config
       if (!(slave->config = ecrt_master_slave_config(master->master, 0, slave->index, slave->vid, slave->pid))) {
@@ -193,7 +199,12 @@ int rtapi_app_main(void) {
 
       // setup pdos
       if (slave->proc_init != NULL) {
-        ec_pdo_entry_reg_t *checkpoint = pdo_entry_regs;
+        ec_pdo_entry_reg_t *checkpoint;
+        pdo_entry_regs = slave->sync_unit->pdo_entry_regs;
+        while (pdo_entry_regs->index != 0) {
+          pdo_entry_regs++;
+        }
+        checkpoint = pdo_entry_regs;
         if ((slave->proc_init(comp_id, slave, &pdo_entry_regs)) != 0) {
           goto fail2;
         }
@@ -234,13 +245,13 @@ int rtapi_app_main(void) {
       }
     }
 
-    // terminate PDO entries
-    pdo_entry_regs->index = 0;
-
-    // register PDO entries
-    if (ecrt_domain_reg_pdo_entry_list(master->domain, master->pdo_entry_regs)) {
-      rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s PDO entry registration failed\n", master->name);
-      goto fail2;
+    // register PDO entries for every Sync Unit domain
+    for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+      if (ecrt_domain_reg_pdo_entry_list(sync_unit->domain, sync_unit->pdo_entry_regs)) {
+        rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s PDO entry registration failed\n",
+          master->name, sync_unit->name);
+        goto fail2;
+      }
     }
 
     // initialize dc sync
@@ -281,9 +292,19 @@ int rtapi_app_main(void) {
       goto fail2;
     }
 
-    // Get internal process data for domain
-    master->process_data = ecrt_domain_data(master->domain);
-    master->process_data_len = ecrt_domain_size(master->domain);
+    // Get internal process data for every domain
+    for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+      sync_unit->process_data = ecrt_domain_data(sync_unit->domain);
+      sync_unit->process_data_len = ecrt_domain_size(sync_unit->domain);
+      if (master->process_data == NULL) {
+        master->process_data = sync_unit->process_data;
+        master->process_data_len = sync_unit->process_data_len;
+      }
+      rtapi_print_msg(RTAPI_MSG_DBG,
+        LCEC_MSG_PFX "master %s syncUnit %s cycle=%u ns divider=%u process_data_len=%d\n",
+        master->name, sync_unit->name, sync_unit->cycle_time,
+        sync_unit->cycle_divider, sync_unit->process_data_len);
+    }
 
     // init hal data
     rtapi_snprintf(name, HAL_NAME_LEN, "%s.%s", LCEC_MODULE_NAME, master->name);
@@ -388,6 +409,7 @@ int lcec_parse_config(void) {
   int slave_count;
   lcec_master_t *master;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
   ec_pdo_entry_reg_t *pdo_entry_regs;
   LCEC_CONF_TYPE_T conf_type;
   LCEC_CONF_MASTER_T *master_conf;
@@ -472,6 +494,11 @@ int lcec_parse_config(void) {
 
         slave = lcec_create_slave(master, slave_conf, &slave_conf_state);
         if (slave == NULL) {
+          goto fail2;
+        }
+
+        slave->sync_unit = lcec_master_get_sync_unit(master, slave_conf->syncUnit, slave_conf->syncUnitCycle);
+        if (slave->sync_unit == NULL) {
           goto fail2;
         }
 
@@ -602,15 +629,23 @@ int lcec_parse_config(void) {
     // stage 3 preinit: sum required pdo mappings
     for (slave = master->first_slave; slave != NULL; slave = slave->next) {
       master->pdo_entry_count += slave->pdo_entry_count;
+      slave->sync_unit->pdo_entry_count += slave->pdo_entry_count;
     }
 
-    // alloc mem for pdo mappings
-    pdo_entry_regs = lcec_zalloc(sizeof(ec_pdo_entry_reg_t) * (master->pdo_entry_count + 1));
-    if (pdo_entry_regs == NULL) {
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "Unable to allocate master %s PDO entry memory\n", master->name);
-      goto fail2;
+    // alloc mem for pdo mappings per Sync Unit/domain
+    for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+      pdo_entry_regs = lcec_zalloc(sizeof(ec_pdo_entry_reg_t) * (sync_unit->pdo_entry_count + 1));
+      if (pdo_entry_regs == NULL) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+          LCEC_MSG_PFX "Unable to allocate master %s syncUnit %s PDO entry memory\n",
+          master->name, sync_unit->name);
+        goto fail2;
+      }
+      sync_unit->pdo_entry_regs = pdo_entry_regs;
+      if (master->pdo_entry_regs == NULL) {
+        master->pdo_entry_regs = pdo_entry_regs;
+      }
     }
-    master->pdo_entry_regs = pdo_entry_regs;
   }
 
   return slave_count;
@@ -665,10 +700,8 @@ void lcec_clear_config(void) {
     // release master
     lcec_shutdown_master(master);
 
-    // free PDO entry memory
-    if (master->pdo_entry_regs != NULL) {
-      lcec_free(master->pdo_entry_regs);
-    }
+    // free Sync Unit/domain configuration
+    lcec_free_sync_units(master);
 
     // free master
     lcec_free(master);

--- a/src/main.c
+++ b/src/main.c
@@ -217,6 +217,15 @@ int rtapi_app_main(void) {
 
       // configure dc for this slave
       if (slave->dc_conf != NULL) {
+        if (slave->sync_unit->cycle_divider > 1 &&
+            slave->dc_conf->sync0Cycle > 0 &&
+            slave->dc_conf->sync0Cycle != slave->sync_unit->cycle_time) {
+          rtapi_print_msg(RTAPI_MSG_WARN,
+            LCEC_MSG_PFX "slave %s.%s syncUnit %s cycle=%u ns but DC sync0Cycle=%u ns; "
+            "set dcConf sync0Cycle to the slave hardware cycle or keep this slave in a matching syncUnit\n",
+            master->name, slave->name, slave->sync_unit->name, slave->sync_unit->cycle_time,
+            slave->dc_conf->sync0Cycle);
+        }
         ecrt_slave_config_dc(slave->config, slave->dc_conf->assignActivate,
           slave->dc_conf->sync0Cycle, slave->dc_conf->sync0Shift,
           slave->dc_conf->sync1Cycle, slave->dc_conf->sync1Shift);

--- a/src/master.c
+++ b/src/master.c
@@ -174,6 +174,71 @@ fail0:
   return NULL;
 }
 
+lcec_sync_unit_t *lcec_master_get_sync_unit(lcec_master_t *master, const char *name, uint32_t cycle_time) {
+  lcec_sync_unit_t *sync_unit;
+  unsigned int cycle_divider;
+
+  if (cycle_time == 0 || master->app_time_period == 0 || (cycle_time % master->app_time_period) != 0) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+      LCEC_MSG_PFX "master %s syncUnit %s cycle %u is not a positive multiple of appTimePeriod %u\n",
+      master->name, name, cycle_time, master->app_time_period);
+    return NULL;
+  }
+
+  cycle_divider = cycle_time / master->app_time_period;
+  if (cycle_divider == 0) {
+    cycle_divider = 1;
+  }
+
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    if (strncmp(sync_unit->name, name, LCEC_CONF_STR_MAXLEN) == 0) {
+      if (sync_unit->cycle_time != cycle_time) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+          LCEC_MSG_PFX "master %s syncUnit %s cycle mismatch (%u != %u)\n",
+          master->name, name, sync_unit->cycle_time, cycle_time);
+        return NULL;
+      }
+      return sync_unit;
+    }
+  }
+
+  sync_unit = lcec_zalloc(sizeof(lcec_sync_unit_t));
+  if (sync_unit == NULL) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+      LCEC_MSG_PFX "Unable to allocate master %s syncUnit %s memory\n",
+      master->name, name);
+    return NULL;
+  }
+
+  strncpy(sync_unit->name, name, LCEC_CONF_STR_MAXLEN);
+  sync_unit->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+  sync_unit->cycle_time = cycle_time;
+  sync_unit->cycle_divider = cycle_divider;
+  sync_unit->queued = 1;
+
+  LCEC_LIST_APPEND(master->first_sync_unit, master->last_sync_unit, sync_unit);
+  return sync_unit;
+}
+
+void lcec_free_sync_units(lcec_master_t *master) {
+  lcec_sync_unit_t *sync_unit, *prev_sync_unit;
+
+  sync_unit = master->last_sync_unit;
+  while (sync_unit != NULL) {
+    prev_sync_unit = sync_unit->prev;
+
+    if (sync_unit->pdo_entry_regs != NULL) {
+      lcec_free(sync_unit->pdo_entry_regs);
+    }
+
+    lcec_free(sync_unit);
+    sync_unit = prev_sync_unit;
+  }
+
+  master->first_sync_unit = NULL;
+  master->last_sync_unit = NULL;
+}
+
 #ifdef EC_USPACE_MASTER
 /**
  * @brief Open the EtherCAT master (userspace build).
@@ -350,6 +415,7 @@ void lcec_shutdown_master(lcec_master_t *master) {
 void lcec_read_master(void *arg, long period) {
   lcec_master_t *master = (lcec_master_t *) arg;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
   int check_states;
 
   // check period
@@ -376,7 +442,13 @@ void lcec_read_master(void *arg, long period) {
   // receive process data & master state
   rtapi_mutex_get(&master->mutex);
   ecrt_master_receive(master->master);
-  ecrt_domain_process(master->domain);
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    sync_unit->process = sync_unit->queued;
+    if (sync_unit->process) {
+      ecrt_domain_process(sync_unit->domain);
+      sync_unit->queued = 0;
+    }
+  }
   if (check_states) {
     ecrt_master_state(master->master, &master->ms);
   }
@@ -403,7 +475,9 @@ void lcec_read_master(void *arg, long period) {
     }
 
     // process read function
-    if (slave->proc_read != NULL) {
+    if (slave->sync_unit->process && slave->proc_read != NULL) {
+      master->process_data = slave->sync_unit->process_data;
+      master->process_data_len = slave->sync_unit->process_data_len;
       slave->proc_read(slave, period);
     }
   }
@@ -431,10 +505,23 @@ void lcec_read_master(void *arg, long period) {
 void lcec_write_master(void *arg, long period) {
   lcec_master_t *master = (lcec_master_t *) arg;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
+
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    if (sync_unit->cycle_counter == 0) {
+      sync_unit->write = 1;
+      sync_unit->cycle_counter = sync_unit->cycle_divider - 1;
+    } else {
+      sync_unit->write = 0;
+      sync_unit->cycle_counter--;
+    }
+  }
 
   // process slaves
   for (slave = master->first_slave; slave != NULL; slave = slave->next) {
-    if (slave->proc_write != NULL) {
+    if (slave->sync_unit->write && slave->proc_write != NULL) {
+      master->process_data = slave->sync_unit->process_data;
+      master->process_data_len = slave->sync_unit->process_data_len;
       slave->proc_write(slave, period);
     }
   }
@@ -442,7 +529,12 @@ void lcec_write_master(void *arg, long period) {
   rtapi_mutex_get(&master->mutex);
 
   // queue process data
-  ecrt_domain_queue(master->domain);
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    if (sync_unit->write) {
+      ecrt_domain_queue(sync_unit->domain);
+      sync_unit->queued = 1;
+    }
+  }
 
   // sync distributed clock just before master_send to set
   // most accurate master clock time

--- a/src/master.c
+++ b/src/master.c
@@ -118,6 +118,10 @@ void lcec_update_master_hal(lcec_master_data_t *hal_data, ec_master_state_t *ms)
   *(hal_data->all_op) = (ms->al_states == 0x08);
 }
 
+static int lcec_master_all_op(lcec_master_t *master) {
+  return master->ms.al_states == EC_AL_STATE_OP;
+}
+
 /**
  * @brief Create and initialise an @c lcec_master_t from its configuration.
  *
@@ -430,8 +434,11 @@ void lcec_read_master(void *arg, long period) {
   // set master time in nano-seconds
   master->dcsync_callbacks.cycle_start(master);
 
-  // get state check flag
-  if (master->state_update_timer > 0) {
+  // Poll state every cycle until OP so startup/fault recovery keeps all domains active.
+  if (!lcec_master_all_op(master)) {
+    check_states = 1;
+    master->state_update_timer = 0;
+  } else if (master->state_update_timer > 0) {
     check_states = 0;
     master->state_update_timer -= period;
   } else {
@@ -506,9 +513,14 @@ void lcec_write_master(void *arg, long period) {
   lcec_master_t *master = (lcec_master_t *) arg;
   lcec_slave_t *slave;
   lcec_sync_unit_t *sync_unit;
+  int force_cycle;
 
+  force_cycle = !lcec_master_all_op(master);
   for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
-    if (sync_unit->cycle_counter == 0) {
+    if (force_cycle) {
+      sync_unit->write = 1;
+      sync_unit->cycle_counter = 0;
+    } else if (sync_unit->cycle_counter == 0) {
       sync_unit->write = 1;
       sync_unit->cycle_counter = sync_unit->cycle_divider - 1;
     } else {

--- a/src/master.c
+++ b/src/master.c
@@ -434,8 +434,8 @@ void lcec_read_master(void *arg, long period) {
   // set master time in nano-seconds
   master->dcsync_callbacks.cycle_start(master);
 
-  // Poll state every cycle until OP so startup/fault recovery keeps all domains active.
-  if (!lcec_master_all_op(master)) {
+  // Poll state every cycle until OP is reached once.
+  if (!master->sync_units_started) {
     check_states = 1;
     master->state_update_timer = 0;
   } else if (master->state_update_timer > 0) {
@@ -458,6 +458,9 @@ void lcec_read_master(void *arg, long period) {
   }
   if (check_states) {
     ecrt_master_state(master->master, &master->ms);
+  }
+  if (!master->sync_units_started && lcec_master_all_op(master)) {
+    master->sync_units_started = 1;
   }
   rtapi_mutex_give(&master->mutex);
 
@@ -515,7 +518,7 @@ void lcec_write_master(void *arg, long period) {
   lcec_sync_unit_t *sync_unit;
   int force_cycle;
 
-  force_cycle = !lcec_master_all_op(master);
+  force_cycle = !master->sync_units_started;
   for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
     if (force_cycle) {
       sync_unit->write = 1;

--- a/src/priv.h
+++ b/src/priv.h
@@ -70,6 +70,10 @@ extern int64_t dc_time_offset;    /**< Nanosecond offset applied when computing 
 
 /** @brief Create and initialise an @c lcec_master_t. @see master.c */
 lcec_master_t * lcec_create_master(LCEC_CONF_MASTER_T *master_conf);
+/** @brief Find or create a master's Sync Unit and validate its cycle. @see master.c */
+lcec_sync_unit_t *lcec_master_get_sync_unit(lcec_master_t *master, const char *name, uint32_t cycle_time);
+/** @brief Free all Sync Units belonging to a master. @see master.c */
+void lcec_free_sync_units(lcec_master_t *master);
 /** @brief Open the EtherCAT master (userspace or kernel build). @see master.c */
 int lcec_startup_master(lcec_master_t *master);
 /** @brief Release the EtherCAT master and free transport resources. @see master.c */

--- a/src/slave.c
+++ b/src/slave.c
@@ -94,6 +94,9 @@ lcec_slave_t *lcec_create_slave(lcec_master_t *master, LCEC_CONF_SLAVE_T *slave_
   slave->type = slave_conf->type;
   strncpy(slave->name, slave_conf->name, LCEC_CONF_STR_MAXLEN);
   slave->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+  strncpy(slave->sync_unit_name, slave_conf->syncUnit, LCEC_CONF_STR_MAXLEN);
+  slave->sync_unit_name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+  slave->sync_unit_cycle = slave_conf->syncUnitCycle;
   slave->master = master;
 
   if (type != NULL) {


### PR DESCRIPTION
solution of issue #157 

This PR adds Sync Unit support so slaves on the same EtherCAT master can be grouped into separate process-data domains and exchanged at different integer-multiple update rates.

What changed:
- Added `syncUnit` and `syncUnitCycle` slave XML attributes.
- Slaves with the same `syncUnit` share one EtherCAT domain.
- Each Sync Unit is queued/processed only on its configured cycle divider.
- Existing configs keep the old behavior via default `syncUnit="default"` and `syncUnitCycle="*1"`.
- Added documentation and an `examples/sync-units` XML example.

Notes:
- `syncUnitCycle` must be a positive multiple of `appTimePeriod`.
- All slaves in the same Sync Unit must use the same cycle.
- This does not replace DC configuration; DC-capable slaves should still use `<dcConf>` aligned with their intended hardware update period.